### PR TITLE
Cache views when running warmup script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
         ],
         "warmup": [
             "php artisan config:cache",
-            "php artisan route:cache"
+            "php artisan route:cache",
+            "php artisan view:cache"
         ]
     }
 }


### PR DESCRIPTION
Generate view cache following an app restart to reduce the overhead when accessing a view for the first time. Any existing views are cleared as part of the command.