### PR TITLE
Add default PHP and Nginx request body sizes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,8 @@ gzip_types
   text/x-component
   text/x-cross-domain-policy;
 
+client_max_body_size 8M;
+
 location / {
     try_files $uri $uri/ /index.php?$query_string;
 }

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,0 +1,2 @@
+post_max_size = 8M
+upload_max_filesize = 2M


### PR DESCRIPTION
Provide default PHP post and upload sizes to demonstrate[ heroku's recommended .user.ini usage](https://devcenter.heroku.com/articles/custom-php-settings#user-ini-files-recommended), and match these to [nginx's client_max_body_size](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)