### PR TITLE
Add request timeout limit

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,8 @@ gzip_types
 
 client_max_body_size 8M;
 
+fastcgi_read_timeout 10s;
+
 location / {
     try_files $uri $uri/ /index.php?$query_string;
 }

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,2 +1,3 @@
+max_execution_time = 10
 post_max_size = 8M
 upload_max_filesize = 2M


### PR DESCRIPTION
Provide a default request timeout limit to follow [Heroku's recommendation](https://devcenter.heroku.com/articles/request-timeout) of "setting a timeout within your application and keeping the value well under 30 seconds, such as 10 or 15 seconds"

This helps prevent the [timeout behaviour](https://devcenter.heroku.com/articles/request-timeout#timeout-behavior) where connections exceed Heroku's 30 second limit and are then terminated, however as the web dyno is left untouched subsequent requests may then be routed to the same process causing further degradation.

The timeout limit is specified both for Nginx and PHP for completeness, however the Nginx limit will take precedence for web requests as this handles the request prior to PHP. The PHP limit will not interfere with the scheduler dyno as this is executed from the command line, and therefore max_execution_time defaults to zero as [.user.ini is not read](https://devcenter.heroku.com/articles/custom-php-settings#user-ini-files-recommended).