### PR TITLE
Buildpack order

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,10 +33,10 @@
   ],
   "buildpacks": [
     {
-      "url": "heroku/php"
+      "url": "heroku/nodejs"
     },
     {
-      "url": "heroku/nodejs"
+      "url": "heroku/php"
     }
   ]
 }


### PR DESCRIPTION
Re-order the buildpacks so that the app is correctly identified as being a PHP application.

When adding multiple buildpacks the ["last buildpack in the list will be used to determine the process types for the application"](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#viewing-buildpacks), therefore the app is currently identified as a Node.js application by Heroku. This is further confirmed when a release takes place as a single web worker process is the [default for Node.js](https://devcenter.heroku.com/articles/node-concurrency#tuning-the-concurrency-level) and is stated in the app's log.

```
2020-01-10T21:26:48.063111+00:00 app[web.1]: Using WEB_CONCURRENCY=1 processes.
```

By placing the PHP buildpack as the last buildpack statement in app.json, releases are now identified as PHP and the correct [PHP web concurrency level](https://devcenter.heroku.com/articles/php-concurrency#web_concurrency-defaults) is then used.

```
2020-01-10T21:45:59.065206+00:00 app[web.1]: Optimizing defaults for 1X dyno...
2020-01-10T21:45:59.105434+00:00 app[web.1]: 4 processes at 128MB memory limit.
```
Although the single web process may suffice for small apps, a higher concurrency level will be needed for when dealing with larger or more complex projects.

