### PR TITLE
Add default memory limit

### DIFF
--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,3 +1,4 @@
 max_execution_time = 10
+memory_limit = 128M
 post_max_size = 8M
 upload_max_filesize = 2M


### PR DESCRIPTION
Provide a default PHP memory limit to demonstrate [heroku's primary method of adjusting PHP application concurrency](https://devcenter.heroku.com/articles/php-concurrency).

The specified memory limit of `128M` matches [Heroku's default value](https://devcenter.heroku.com/articles/php-concurrency#web_concurrency-defaults) if no memory limit is explicitly defined, and results in 4 child processes for free dyno types.

The chosen memory limit should be ample for any kind of application and it's likely many apps will use a lot less. By simply lowering the memory limit the number of processes can be increased and with it the number of requests which can be handled concurrently.